### PR TITLE
Shim for _.uniq no longer needed

### DIFF
--- a/angular-underscore.js
+++ b/angular-underscore.js
@@ -32,18 +32,6 @@
     });
   });
 
-  // Shiv "uniq" works for iterator without "isSorted" parameter.
-  _.uniq = _.unique = function() {
-    var args = arguments;
-
-    if(_.isFunction(args[1])) {
-      args[2] = args[1];
-      args[1] = false;
-    }
-
-    return _.uniq.apply(_, args);
-  };
-
   // Shiv "filter", "reject" to angular's built-in,
   // and reserve underscore's feature(works on obj).
   ng.injector(['ng']).invoke(function($filter) {


### PR DESCRIPTION
In more recent versions of Underscore (since Nov 4), the _.uniq function [contains essentially the exact same shim code](https://github.com/documentcloud/underscore/blob/master/underscore.js#L449-L453) you include in angular_underscore. This means that if you're running angular_underscore with, say, 1.4.4, you get this:

```
_.uniq( [1, 1, 2 ])
// RangeError: Maximum call stack size exceeded
```

So the shim is no longer needed here -- Underscore does it for you.
