### PR TITLE
Update bower.json to list underscore as a dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "version": "0.5.0",
   "main": "angular-underscore.js",
   "dependencies": {
-    "underscore": "~1.8.3"
+    "underscore": "~1.8.3",
+    "angular": "^1.4.0"
   },
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,9 @@
   "name": "angular-underscore",
   "version": "0.5.0",
   "main": "angular-underscore.js",
+  "dependencies": {
+    "underscore": "~1.8.3"
+  },
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
This fixes issues with wiredep dependency load order.  Right now, underscore and angular will sometimes be loaded AFTER this module which results in a reference error and breaks the app during boot.
